### PR TITLE
The setting magic_quotes_runtime is removed in PHP5.4.0 (see: https:/…

### DIFF
--- a/Classes/fpdf/fpdf.php
+++ b/Classes/fpdf/fpdf.php
@@ -1040,8 +1040,11 @@ protected function _dochecks()
 	if(ini_get('mbstring.func_overload') & 2)
 		$this->Error('mbstring overloading must be disabled');
 	// Ensure runtime magic quotes are disabled
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(0);
+	if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+		if(get_magic_quotes_runtime()) {
+			@set_magic_quotes_runtime(0);
+		}
+	}
 }
 
 protected function _checkoutput()

--- a/Classes/fpdf/makefont/makefont.php
+++ b/Classes/fpdf/makefont/makefont.php
@@ -384,8 +384,11 @@ function MakeDefinitionFile($file, $type, $enc, $embed, $subset, $map, $info)
 function MakeFont($fontfile, $enc='cp1252', $embed=true, $subset=true)
 {
 	// Generate a font definition file
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(false);
+	if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+		if(get_magic_quotes_runtime()) {
+			@set_magic_quotes_runtime(0);
+		}
+	}
 	ini_set('auto_detect_line_endings', '1');
 
 	if(!file_exists($fontfile))


### PR DESCRIPTION
The setting magic_quotes_runtime is removed in PHP5.4.0 (see: https://www.php.net/manual/en/info.configuration.php#ini.magic-quotes-runtime) so the function call is unneeded. Added backwards compatibility by wrapping the calls in an if statement checking phpversion using version_compare.

Also, this fixes an error we were having with :get_magic_quotes_runtime()":

```
Function get_magic_quotes_runtime() is deprecated in PHP 7+
```
This function is in the /rguedes/pdfmerger package in this file: /Classes/fpdf/fpdf.php, line 1043